### PR TITLE
Fix desugaring of lambdas with reversible patterns

### DIFF
--- a/src/Language/Sparcl/Desugar.hs
+++ b/src/Language/Sparcl/Desugar.hs
@@ -60,11 +60,7 @@ desugarExp (Loc _ expr) = go expr
     go (S.App e1 e2)  =
       mkApp <$> desugarExp e1 <*> desugarExp e2
 
-    go (S.Abs [] e) = desugarExp e
-    go (S.Abs (p:ps) e) = withNewName $ \n -> do
-      r <- desugarAlts [(p, S.Clause (noLoc $ S.Abs ps e) (S.HDecls () []) Nothing)]
-      return $ mkAbs n (makeCase (C.Var n) r)
-
+    go (S.Abs ps e) = desugarRHS [(ps, S.Clause e (S.HDecls () []) Nothing)]
 
     go (S.Con (c, ty)) = do
       ty' <- zonkType ty


### PR DESCRIPTION
The desugaring of lambdas does not currently work correctly for functions with reversible patterns. For example, the following function type checks:
```haskell
def myFun = \(rev x) n -> rev (x, n)
```

But evaluating it gives the following error:
```
Sparcl> myFun (const eqInt 0) (const eqInt 1)
Runtime Error:
the first component of application must be a function, but we got <reversible computation> from myFun (const eqInt 0)
```

This PR updates `Desugar.hs` so that lambda patterns are treated the same way as `def` patterns, which fixes the issue.